### PR TITLE
cleanup unused functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,9 @@ IGNORE_NOT_FOUND ?= true
 
 #.PHONY: undeploy-on-kind
 #undeploy-on-kind: ## Undeploy operator and agent from the Kind GPU cluster.
-#	@echo "Undeploying operator and agent from Kind GPU cluster: $(KIND_CLUSTER_NAME)"
+#	@echo "Un-deploying operator and agent from Kind GPU cluster: $(KIND_CLUSTER_NAME)"
 #	$(KUSTOMIZE) build config/kind-gpu | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
-#	@echo "Undeployment from Kind GPU cluster $(KIND_CLUSTER_NAME) completed."
+#	@echo "Un-deployment from Kind GPU cluster $(KIND_CLUSTER_NAME) completed."
 
 #.PHONY: run-on-kind
 #run-on-kind: setup-kind kind-load-images deploy-on-kind ## Setup Kind cluster, load images, and deploy
@@ -123,7 +123,7 @@ deploy: ## Deploy CSI Controller and Node to K8s cluster specified in ~/.kube/co
 	kubectl apply -f manifests/controller-plugin.yaml
 	@echo "Deploying CSI Node RBAC."
 	kubectl apply -f manifests/rbac-node.yaml
-	@echo "Deploying CSI Node Daemonset."
+	@echo "Deploying CSI Node DaemonSet."
 	kubectl apply -f manifests/node-plugin.yaml
 	@echo "Add label tkm-test-node= to node kind-gpu-sim-worker."
 	kubectl label node kind-gpu-sim-worker tkm-test-node=true
@@ -131,15 +131,15 @@ deploy: ## Deploy CSI Controller and Node to K8s cluster specified in ~/.kube/co
 
 .PHONY: undeploy
 undeploy: undeploy-test-pod ## Undeploy CSI Controller and Node from K8s cluster specified in ~/.kube/config.
-	@echo "Undeploying CSI Node Daemonset."
+	@echo "Un-deploying CSI Node DaemonSet."
 	kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f manifests/node-plugin.yaml
-	@echo "Undeploying CSI Node RBAC."
+	@echo "Un-deploying CSI Node RBAC."
 	kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f manifests/rbac-node.yaml
-	@echo "Undeploying CSI Controller Deployment."
+	@echo "Un-deploying CSI Controller Deployment."
 	kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f manifests/controller-plugin.yaml
-	@echo "Undeploying CSI Controller RBAC."
+	@echo "Un-deploying CSI Controller RBAC."
 	kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f manifests/rbac-controller.yaml
-	@echo "Undeploying CSI-Driver Object."
+	@echo "Un-deploying CSI-Driver Object."
 	kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f manifests/csi-driver.yaml
 	@echo "Remove label tkm-test-node= from node kind-gpu-sim-worker."
 	kubectl label node kind-gpu-sim-worker tkm-test-node-
@@ -152,5 +152,5 @@ deploy-test-pod: ## Deploying TritonKernelCacheCluster Instance and a Test Pod.
 
 .PHONY: undeploy-test-pod
 undeploy-test-pod: ## Deploy CSI Controller and Node to K8s cluster specified in ~/.kube/config.
-	@echo "Undeploying TritonKernelCacheCluster Instance and Test Pod."
+	@echo "Un-deploying TritonKernelCacheCluster Instance and Test Pod."
 	kubectl delete --ignore-not-found=$(IGNORE_NOT_FOUND) -f examples/testpod.yaml

--- a/pkgs/driver/controller_server.go
+++ b/pkgs/driver/controller_server.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"context"
-	"fmt"
 
 	// "github.com/tkm/tkmgo"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -10,595 +9,58 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// BytesInGigabyte describes how many bytes are in a gigabyte
-const BytesInGigabyte int64 = 1024 * 1024 * 1024
-
-// TkmVolumeAvailableRetries is the number of times we will retry to check if a volume is available
-const TkmVolumeAvailableRetries int = 20
-
-var supportedAccessModes = map[csi.VolumeCapability_AccessMode_Mode]struct{}{
-	csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER:      {},
-	csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY: {},
-}
-
-// CreateVolume is the first step when a PVC tries to create a dynamic volume
+// CreateVolume is the first step when a PVC tries to create a dynamic volume.
+// This is not needed for TKM.
 func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-	d.log.Info("Request: CreateVolume")
-
-	if req.Name == "" {
-		return nil, status.Error(codes.InvalidArgument, "CreateVolume Name must be provided")
-	}
-
-	if len(req.VolumeCapabilities) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "CreateVolume Volume capabilities must be provided")
-	}
-
-	d.log.Info("Creating volume", "name", req.Name, "capabilities", req.VolumeCapabilities)
-
-	// Check capabilities
-	for _, cap := range req.VolumeCapabilities {
-		if _, ok := supportedAccessModes[cap.GetAccessMode().GetMode()]; !ok {
-			return nil, status.Error(codes.InvalidArgument, "CreateVolume access mode isn't supported")
-		}
-		if _, ok := cap.GetAccessType().(*csi.VolumeCapability_Block); ok {
-			return nil, status.Error(codes.InvalidArgument, "CreateVolume block types aren't supported, only mount types")
-		}
-	}
-
-	// Determine required size
-	bytes, err := getVolSizeInBytes(req.GetCapacityRange())
-	if err != nil {
-		return nil, err
-	}
-
-	desiredSize := bytes / BytesInGigabyte
-	if (bytes % BytesInGigabyte) != 0 {
-		desiredSize++
-	}
-
-	d.log.V(1).Info("Volume size determined", "size_gb", desiredSize)
-
-	d.log.V(1).Info("Listing current volumes in TKM API")
-	/*
-		volumes, err := d.TkmClient.ListVolumes()
-		if err != nil {
-			d.log.Error(err, "Unable to list volumes in TKM API")
-			return nil, err
-		}
-		for _, v := range volumes {
-			if v.Name == req.Name {
-				d.log.V(1).Info("Volume already exists", "volume_id", v.ID)
-				if v.SizeGigabytes != int(desiredSize) {
-					return nil, status.Error(codes.AlreadyExists, "Volume already exists with a differnt size")
-				}
-
-				available, err := d.waitForVolumeStatus(&v, "available", TkmVolumeAvailableRetries)
-				if err != nil {
-					d.log.Error(err, "Unable to wait for volume availability in TKM API")
-					return nil, err
-				}
-
-				if available {
-					return &csi.CreateVolumeResponse{
-						Volume: &csi.Volume{
-							VolumeId:      v.ID,
-							CapacityBytes: int64(v.SizeGigabytes) * BytesInGigabyte,
-						},
-					}, nil
-				}
-
-				d.log.Error(fmt.Errorf("TKM Volume is not 'available'"), "status", v.Status)
-				return nil,
-					status.Errorf(
-						codes.Unavailable,
-						"Volume isn't available to be attached, state is currently %s",
-						v.Status,
-					)
-			}
-		}
-	*/
-
-	// TODO: Uncomment after client implementation is complete.
-	// snapshotID := ""
-	// if volSource := req.GetVolumeContentSource(); volSource != nil {
-	// 	if _, ok := volSource.GetType().(*csi.VolumeContentSource_Snapshot); !ok {
-	// 		return nil, status.Error(codes.InvalidArgument, "Unsupported volumeContentSource type")
-	// 	}
-	// 	snapshot := volSource.GetSnapshot()
-	// 	if snapshot == nil {
-	// 		return nil,
-	// 			status.Error(
-	// 				codes.InvalidArgument,
-	// 				"Volume content source type is set to Snapshot, but the Snapshot is not provided",
-	//			)
-	// 	}
-	// 	snapshotID = snapshot.GetSnapshotId()
-	// 	if snapshotID == "" {
-	// 		return nil,
-	// 			status.Error(
-	// 				codes.InvalidArgument,
-	// 				"Volume content source type is set to Snapshot, but the SnapshotID is not provided",
-	//			)
-	// 	}
-	// }
-
-	d.log.V(1).Info("Volume doesn't currently exist, will need creating")
-
-	d.log.V(1).Info("Requesting available capacity in client's quota from the TKM API")
-	/*
-		quota, err := d.TkmClient.GetQuota()
-		if err != nil {
-			d.log.Error(err, "Unable to get quota from TKM API")
-			return nil, err
-		}
-		availableSize := int64(quota.DiskGigabytesLimit - quota.DiskGigabytesUsage)
-		if availableSize < desiredSize {
-			d.log.Error(fmt.Errorf("Requested volume would exceed storage quota available"))
-			return nil,
-				status.Errorf(
-					codes.OutOfRange,
-					"Requested volume would exceed volume space quota by %d GB",
-					desiredSize-availableSize,
-				)
-		} else if quota.DiskVolumeCountUsage >= quota.DiskVolumeCountLimit {
-			d.log.Error(fmt.Errorf("Requested volume would exceed volume quota available"))
-			return nil,
-				status.Errorf(codes.OutOfRange,
-					"Requested volume would exceed volume count limit quota of %d",
-					quota.DiskVolumeCountLimit,
-				)
-		}
-
-		d.log.V(1).Info("Quota has sufficient capacity remaining",
-			"disk_gb_limit", quota.DiskGigabytesLimit, "disk_gb_usage", quota.DiskGigabytesUsage)
-	*/
-
-	/*
-		v := &tkmgo.VolumeConfig{
-			Name:          req.Name,
-			Region:        d.Region,
-			Namespace:     d.Namespace,
-			ClusterID:     d.ClusterID,
-			SizeGigabytes: int(desiredSize),
-			// SnapshotID: snapshotID, // TODO: Uncomment after client implementation is complete.
-		}
-	*/
-	d.log.V(1).Info("Creating volume in TKM API")
-	/*
-		result, err := d.TkmClient.NewVolume(v)
-		if err != nil {
-			d.log.Error(err, "Unable to create volume in TKM API")
-			return nil, err
-		}
-	*/
-
-	d.log.Info("Volume created in TKM API", "volume_id", 14567 /*result.ID*/)
-
-	/*
-		volume, err := d.TkmClient.GetVolume(result.ID)
-		if err != nil {
-			d.log.Error(err, "Unable to get volume updates in TKM API")
-			return nil, err
-		}
-
-		d.log.V(1).Info("Waiting for volume to become available in TKM API", "volume_id", result.ID)
-		available, err := d.waitForVolumeStatus(volume, "available", TkmVolumeAvailableRetries)
-		if err != nil {
-			d.log.Error(err, "Volume availability never completed successfully in TKM API")
-			return nil, err
-		}
-	*/
-	available := true
-
-	if available {
-		return &csi.CreateVolumeResponse{
-			Volume: &csi.Volume{
-				// VolumeId:      volume.ID,
-				VolumeId:      "14567",
-				CapacityBytes: int64(1 /*v.SizeGigabytes*/) * BytesInGigabyte,
-			},
-		}, nil
-	}
-
-	d.log.Error(err, "TKM Volume is not 'available'")
-	return nil,
-		status.Errorf(
-			codes.Unavailable,
-			"TKM Volume %q is not \"available\", state currently is %q",
-			"14567", /*volume.ID*/
-			"error", /*volume.Status*/
-		)
+	d.log.Info("Request: CreateVolume, returning unimplemented")
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// waitForVolumeAvailable will just sleep/loop waiting for TKM's API to report it's available, or hit a defined
-// number of retries
-/*
-func (d *Driver) waitForVolumeStatus(vol *tkmgo.Volume, desiredStatus string, retries int) (bool, error) {
-	d.log.Info("Waiting for Volume to entered desired state", "volume_id", vol.ID, "desired_state", desiredStatus)
-	var v *tkmgo.Volume
-	var err error
-
-	if d.TestMode {
-		return true, nil
-	}
-
-	for i := 0; i < retries; i++ {
-		time.Sleep(5 * time.Second)
-
-		v, err = d.TkmClient.GetVolume(vol.ID)
-		if err != nil {
-			d.log.Error(err, "Unable to get volume updates in TKM API")
-			return false, err
-		}
-
-		if v.Status == desiredStatus {
-			return true, nil
-		}
-	}
-	return false, fmt.Errorf("volume isn't %s, state is currently %s", desiredStatus, v.Status)
-}
-*/
-
-// DeleteVolume is used once a volume is unused and therefore unmounted, to stop the resources being used and
-// subsequent billing
+// DeleteVolume is used once a volume is unused and therefore unmounted, to stop the
+// resources being used and subsequent billing.
+// This is not needed for TKM.
 func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
-	d.log.Info("Request: DeleteVolume", "volume_id", req.VolumeId)
-
-	if req.VolumeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to DeleteVolume")
-	}
-
-	d.log.V(1).Info("Deleting volume in TKM API")
-	/*
-		_, err := d.TkmClient.DeleteVolume(req.VolumeId)
-		if err != nil {
-			if strings.Contains(err.Error(), "DatabaseVolumeNotFoundError") {
-				d.log.Info("Volume already deleted from TKM API", "volume_id", req.VolumeId)
-				return &csi.DeleteVolumeResponse{}, nil
-			}
-
-			d.log.Error(err, "Unable to delete volume in TKM API")
-			return nil, err
-		}
-	*/
-
-	d.log.Info("Volume deleted from TKM API", "volume_id", req.VolumeId)
-
-	return &csi.DeleteVolumeResponse{}, nil
+	d.log.Info("Request: DeleteVolume, returning unimplemented", "volume_id", req.VolumeId)
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ControllerPublishVolume is used to mount an underlying volume to required k3s node
+// ControllerPublishVolume is used to mount an underlying volume to a given Kubernetes node.
+// This is not needed for TKM.
 func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest,
 ) (*csi.ControllerPublishVolumeResponse, error) {
-	d.log.Info("Request: ControllerPublishVolume", "volume_id", req.VolumeId, "node_id", req.NodeId)
-
-	if req.VolumeCapability == nil {
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeCapability to ControllerPublishVolume")
-	}
-
-	if req.VolumeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to ControllerPublishVolume")
-	}
-
-	if req.NodeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "must provide a NodeId to ControllerPublishVolume")
-	}
-
-	d.log.V(1).Info("Check if Node exits")
-	/*
-		cluster, err := d.TkmClient.GetKubernetesCluster(d.ClusterID)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to connect to TKM Api. error: %s", err)
-		}
-		found := false
-		for _, instance := range cluster.Instances {
-			if instance.ID == req.NodeId {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, status.Error(codes.NotFound, "Unable to find instance to attach volume to")
-		}
-
-		d.log.V(1).Info("Finding volume in TKM API")
-		volume, err := d.TkmClient.GetVolume(req.VolumeId)
-		if err != nil {
-			d.log.Error(err, "Unable to find volume for publishing in TKM API")
-			return nil, err
-		}
-		d.log.V(1).Info("Volume found for publishing in TKM API", "volume_id", volume.ID)
-
-		// Check if the volume is already attached to the requested node
-		if volume.InstanceID == req.NodeId && volume.Status == "attached" {
-			d.log.Info("Volume is already attached to the requested instance",
-				"volume_id", volume.ID,
-				"instance_id", req.NodeId)
-			return &csi.ControllerPublishVolumeResponse{}, nil
-		}
-
-		// if the volume is not available, we can't attach it, so error out
-		if volume.Status != "available" && volume.InstanceID != req.NodeId {
-			d.log.Error(fmt.Errorf("Volume is not available to be attached"),
-				"volume_id", volume.ID,
-				"status", volume.Status,
-				"requested_instance_id", req.NodeId,
-				"current_instance_id", volume.InstanceID,
-				"Volume is not available to be attached")
-			return nil,
-				status.Errorf(codes.Unavailable,
-					"Volume %q is not available to be attached, state is currently %q",
-					volume.ID,
-					volume.Status
-				)
-		}
-
-		// Check if the volume is attaching to this node
-		if volume.InstanceID == req.NodeId && volume.Status != "attaching" {
-			// Do nothing, the volume is already attaching
-			d.log.V(1).Info("Volume is already attaching", "volume_id", volume.ID, "status", volume.Status)
-		} else {
-			// Call the TKM API to attach it to a node/instance
-			d.log.V(1).Info("Requesting volume to be attached in TKN API",
-				"volume_id", volume.ID,
-				"volume_status", volume.Status,
-				"reqested_instance_id", req.NodeId)
-
-			volConfig := tkmgo.VolumeAttachConfig{
-				InstanceID: req.NodeId,
-				Region:     d.Region,
-			}
-
-			_, err = d.TkmClient.AttachVolume(req.VolumeId, volConfig)
-			if err != nil {
-				d.log.Error(err, "Unable to attach volume in TKM API")
-				return nil, err
-			}
-			d.log.Info("Volume successfully requested to be attached in TKM API",
-				"volume_id", volume.ID,
-				"instance_id", req.NodeId)
-		}
-
-		time.Sleep(5 * time.Second)
-		// refetch the volume
-		d.log.Info("Fetching volume again to check status after attaching", "volume_id", volume.ID)
-		volume, err = d.TkmClient.GetVolume(req.VolumeId)
-		if err != nil {
-			d.log.Error(err, "Unable to fetch volume from TKM API")
-			return nil, err
-		}
-		if volume.Status != "attached" {
-			d.log.Error(fmt.Errorf("Volume is not in the attached state"), "volume_id", volume.ID, "status", volume.Status)
-			return nil,
-				status.Errorf(codes.Unavailable,
-					"Volume %q is not attached to the requested instance, state is currently %q",
-					volume.ID,
-					volume.Status)
-		}
-
-		if volume.InstanceID != req.NodeId {
-			d.log.Error(fmt.Errorf("Volume is not attached to the requested instance"),
-				"volume_id", volume.ID,
-				"instance_id", req.NodeId)
-			return nil,
-				status.Errorf(codes.Unavailable,
-					"Volume %q is not attached to the requested instance %q, instance id is currently %q",
-					volume.ID,
-					req.NodeId,
-					volume.InstanceID
-				)
-		}
-	*/
-
-	d.log.V(1).Info("Volume successfully attached in TKM API", "volume_id", req.VolumeId /*volume.ID*/)
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	d.log.Info("Request: ControllerPublishVolume, returning unimplemented",
+		"volume_id", req.VolumeId, "node_id", req.NodeId)
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ControllerUnpublishVolume detaches the volume from the k3s node it was connected
+// ControllerUnpublishVolume detaches the volume from the given Kubernetes node it was connected.
+// This is not needed for TKM.
 func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest,
 ) (*csi.ControllerUnpublishVolumeResponse, error) {
-	d.log.Info("Request: ControllerUnpublishVolume", "volume_id", req.VolumeId)
-
-	if req.VolumeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to ControllerUnpublishVolume")
-	}
-
-	/*
-		d.log.V(1).Info("Finding volume in TKM API")
-		volume, err := d.TkmClient.GetVolume(req.VolumeId)
-		if err != nil {
-			if strings.Contains(err.Error(), "DatabaseVolumeNotFoundError") ||
-				strings.Contains(err.Error(), "ZeroMatchesError") {
-				d.log.Info("Volume already deleted from TKM API, pretend it's unmounted", "volume_id", req.VolumeId)
-				return &csi.ControllerUnpublishVolumeResponse{}, nil
-			}
-			d.log.V(1).Info("message", err.Error()).Msg("Error didn't match DatabaseVolumeNotFoundError")
-
-			d.log.Error(err, "Unable to find volume for unpublishing in TKM API")
-			return nil, err
-		}
-
-		d.log.V(1).Info("Volume found for unpublishing in TKM API", "volume_id", volume.ID)
-
-		// If the volume is currently available, it's not attached to anything to return success
-		if volume.Status == "available" {
-			d.log.Info("Volume is already available, no need to unpublish", "volume_id", volume.ID)
-			return &csi.ControllerUnpublishVolumeResponse{}, nil
-		}
-
-		// If requeseted node doesn't match the current volume instance, return success
-		if volume.InstanceID != req.NodeId {
-			d.log.Info("Volume is not attached to the requested instance",
-				"volume_id", volume.ID,
-				"instance_id", volume.InstanceID,
-				"requested_instance_id", req.NodeId)
-			return &csi.ControllerUnpublishVolumeResponse{}, nil
-		}
-
-		if volume.Status != "detaching" {
-			// The volume is either attached to the requested node or the requested node is empty
-			// and the volume is attached, so we need to detach the volume
-			d.log.Info("Requesting volume to be detached",
-				"volume_id", volume.ID,
-				"current_instance_id", volume.InstanceID,
-				"requested_instance_id", req.NodeId,
-				"status", volume.Status)
-
-			_, err = d.TkmClient.DetachVolume(req.VolumeId)
-			if err != nil {
-				d.log.Error(err, "Unable to detach volume in TKM API")
-				return nil, err
-			}
-
-			d.log.Info("Volume sucessfully requested to be detached in TKM API", "volume_id", volume.ID)
-		}
-
-		// Fetch the new state after 5 seconds
-		time.Sleep(5 * time.Second)
-		volume, err = d.TkmClient.GetVolume(req.VolumeId)
-		if err != nil {
-			d.log.Error(err, "Unable to find volume for unpublishing in TKM API")
-			return nil, err
-		}
-	*/
-
-	/*
-		if volume.Status == "available" {
-	*/
-	d.log.V(1).Info("Volume is now available again", "volume_id", req.VolumeId /*volume.ID*/)
-	return &csi.ControllerUnpublishVolumeResponse{}, nil
-	/*
-		}
-	*/
-
-	/*
-		// err that the the volume is not available
-		d.log.Error(fmt.Errorf("TKM Volume did not go back to 'available' status"))
-		return nil,
-			status.Errorf(
-				codes.Unavailable,
-				"TKM Volume %q did not go back to \"available\", state is currently %q",
-				req.VolumeId,
-				volume.Status)
-	*/
+	d.log.Info("Request: ControllerUnpublishVolume, returning unimplemented", "volume_id", req.VolumeId)
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ValidateVolumeCapabilities returns the features of the volume, e.g. RW, RO, RWX
+// ValidateVolumeCapabilities returns the features of the volume, e.g. RW, RO, RWX.
+// This is not needed for TKM.
 func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest,
 ) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	d.log.Info("Request: ValidateVolumeCapabilities", "volume_id", req.VolumeId)
-
-	if req.VolumeId == "" {
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to ValidateVolumeCapabilities")
-	}
-
-	if req.VolumeCapabilities == nil {
-		return nil, status.Error(codes.InvalidArgument, "must provide VolumeCapabilities to ValidateVolumeCapabilities")
-	}
-
-	/*
-		_, err := d.TkmClient.GetVolume(req.VolumeId)
-		if err != nil {
-			return nil, status.Errorf(codes.NotFound, "Unable to fetch volume from TKM API: %s", err)
-		}
-
-		accessModeSupported := false
-		for _, cap := range req.VolumeCapabilities {
-			if _, ok := supportedAccessModes[cap.GetAccessMode().GetMode()]; ok {
-				accessModeSupported = true
-				break
-			}
-		}
-
-		if !accessModeSupported {
-			return nil, status.Errorf(codes.NotFound, "%v not supported", req.GetVolumeCapabilities())
-		}
-	*/
-
-	resp := &csi.ValidateVolumeCapabilitiesResponse{
-		Confirmed: &csi.ValidateVolumeCapabilitiesResponse_Confirmed{
-			VolumeCapabilities: req.VolumeCapabilities,
-		},
-	}
-
-	return resp, nil
+	d.log.Info("Request: ValidateVolumeCapabilities, returning unimplemented", "volume_id", req.VolumeId)
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ListVolumes returns the existing TKM volumes for this customer
+// ListVolumes returns the existing TKM volumes.
+// This is not needed for TKM.
 func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	if req.StartingToken != "" {
-		return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted, "%v not supported", "starting-token")
-	}
-
-	d.log.Info("Request: ListVolumes")
-
-	d.log.V(1).Info("Listing all volume in TKM API")
-	/*
-		volumes, err := d.TkmClient.ListVolumes()
-		if err != nil {
-			d.log.Error(err, "Unable to list volumes in TKM API")
-			return nil, err
-		}
-	*/
-	d.log.V(1).Info("Successfully retrieved all volumes from the TKM API")
-
-	resp := &csi.ListVolumesResponse{
-		Entries: []*csi.ListVolumesResponse_Entry{},
-	}
-
-	/*
-		for _, v := range volumes {
-	*/
-	resp.Entries = append(resp.Entries, &csi.ListVolumesResponse_Entry{
-		Volume: &csi.Volume{
-			CapacityBytes: int64(1 /*v.SizeGigabytes*/) * BytesInGigabyte,
-			VolumeId:      "14567", /*v.ID*/
-			ContentSource: &csi.VolumeContentSource{
-				Type: &csi.VolumeContentSource_Volume{},
-			},
-		},
-		Status: &csi.ListVolumesResponse_VolumeStatus{},
-	})
-	/*
-		}
-	*/
-
-	return resp, nil
+	d.log.Info("Request: ListVolumes, returning unimplemented")
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// GetCapacity calls the TKM API to determine the user's available quota
+// GetCapacity returns the user's available quota.
+// This is not needed for TKM.
 func (d *Driver) GetCapacity(context.Context, *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
-	d.log.Info("Request: GetCapacity")
-
-	d.log.V(1).Info("Requesting available capacity in client's quota from the TKM API")
-	/*
-		quota, err := d.TkmClient.GetQuota()
-		if err != nil {
-			d.log.Error(err, "Unable to get quota in TKM API")
-			return nil, err
-		}
-	*/
-	d.log.V(1).Info("Successfully retrieved quota from the TKM API")
-
-	availableBytes := int64(1 /*quota.DiskGigabytesLimit-quota.DiskGigabytesUsage*/) * BytesInGigabyte
-	d.log.V(1).Info("Available capacity determined", "available_gb", availableBytes/BytesInGigabyte)
-	if availableBytes < BytesInGigabyte {
-		d.log.Error(fmt.Errorf("available capacity is less than 1GB, volumes can't be launched"),
-			"available_bytes", availableBytes)
-	}
-
-	/*
-		if quota.DiskVolumeCountUsage >= quota.DiskVolumeCountLimit {
-			d.log.Error("Number of volumes is at the quota limit, no capacity left")
-			availableBytes = 0
-		}
-	*/
-
-	resp := &csi.GetCapacityResponse{
-		AvailableCapacity: availableBytes,
-	}
-
-	return resp, nil
+	d.log.Info("Request: GetCapacity, returning unimplemented")
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ControllerGetCapabilities returns the capabilities of the controller, what features it implements
@@ -612,9 +74,7 @@ func (d *Driver) ControllerGetCapabilities(context.Context, *csi.ControllerGetCa
 		csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 		csi.ControllerServiceCapability_RPC_GET_CAPACITY,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
-		// TODO: Uncomment after client implementation is complete.
 		// csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
-		// TODO: Uncomment after client implementation is complete.
 		// csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 	}
 
@@ -639,334 +99,50 @@ func (d *Driver) ControllerGetCapabilities(context.Context, *csi.ControllerGetCa
 	return resp, nil
 }
 
-// CreateSnapshot is part of implementing Snapshot & Restore functionality, but we don't support that
+// CreateSnapshot is part of implementing Snapshot & Restore functionality.
+// This is not needed for TKM.
 func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest,
 ) (*csi.CreateSnapshotResponse, error) {
+	d.log.Info("Request: CreateSnapshot, returning unimplemented")
 	return nil, status.Error(codes.Unimplemented, "")
-	// TODO: Uncomment after client implementation is complete.
-	// snapshotName := req.GetName()
-	// sourceVolID := req.GetSourceVolumeId()
-	//
-	// d.log.Info("Request: CreateSnapshot", "snapshot_name", snapshotName, "source_volume_id", sourceVolID)
-	//
-	// if len(snapshotName) == 0 {
-	// 	return nil, status.Error(codes.InvalidArgument, "Snapshot name is required")
-	// }
-	// if len(sourceVolID) == 0 {
-	// 	return nil, status.Error(codes.InvalidArgument, "SourceVolumeId is required")
-	// }
-	//
-	// d.log.V(1).Info("Finding current snapshot in TKM API",
-	// 	"source_volume_id", sourceVolID)
-	//
-	// snapshots, err := d.TkmClient.ListVolumeSnapshotsByVolumeID(sourceVolID)
-	// if err != nil {
-	// 	d.log.Error(err, "Unable to list snapshot in TKM API", "source_volume_id", sourceVolID)
-	// 	return nil, status.Errorf(codes.Internal, "failed to list snapshots by %q: %s", sourceVolID, err)
-	// }
-	//
-	// // Check for an existing snapshot with the specified name.
-	// for _, snapshot := range snapshots {
-	// 	if snapshot.Name != snapshotName {
-	// 		continue
-	// 	}
-	// 	if snapshot.VolumeID == sourceVolID {
-	// 		return &csi.CreateSnapshotResponse{
-	// 			Snapshot: &csi.Snapshot{
-	// 				SnapshotId:     snapshot.SnapshotID,
-	// 				SourceVolumeId: snapshot.VolumeID,
-	// 				CreationTime:   snapshot.CreationTime,
-	// 				SizeBytes:      snapshot.RestoreSize,
-	// 				ReadyToUse:     true,
-	// 			},
-	// 		}, nil
-	// 	}
-	// 	d.log.Error(err,
-	//		"Snapshot with the same name but with different SourceVolumeId already exist",
-	// 		"snapshot_name", snapshotName,
-	// 		"requested_source_volume_id", sourceVolID,
-	// 		"actual_source_volume_id", snapshot.VolumeID)
-	// 	return nil,
-	// 		status.Errorf(
-	// 			codes.AlreadyExists,
-	// 			"snapshot with the same name %q but with different SourceVolumeId already exist",
-	// 			snapshotName
-	//		)
-	// }
-	//
-	// d.log.V(1).Info("Create volume snapshot in TKM API",
-	// 	"snapshot_name", snapshotName,
-	// 	"source_volume_id", sourceVolID)
-	//
-	// result, err := d.TkmClient.CreateVolumeSnapshot(sourceVolID, &tkmgo.VolumeSnapshotConfig{
-	// 	Name: snapshotName,
-	// })
-	// if err != nil {
-	// 	if strings.Contains(err.Error(), "DatabaseVolumeSnapshotLimitExceededError") {
-	// 		d.log.Error(err, "Requested volume snapshot would exceed volume quota available")
-	// 		return nil, status.Errorf(codes.ResourceExhausted, "failed to create volume snapshot due to over quota: %s", err)
-	// 	}
-	// 	d.log.Error(err, "Unable to create snapshot in TKM API")
-	// 	return nil, status.Errorf(codes.Internal, "failed to create volume snapshot: %s", err)
-	// }
-	//
-	// d.log.Info("Snapshot created in TKM API", "snapshot_id", result.SnapshotID)
-	//
-	// // NOTE: Add waitFor logic if creation takes long time.
-	// snapshot, err := d.TkmClient.GetVolumeSnapshot(result.SnapshotID)
-	// if err != nil {
-	// 	d.log.Error(err, "Unsable to get snapshot updates from TKM API", "snapshot_id", result.SnapshotID)
-	// 	return nil, status.Errorf(codes.Internal, "failed to get snapshot by %q: %s", result.SnapshotID, err)
-	// }
-	// return &csi.CreateSnapshotResponse{
-	// 	Snapshot: &csi.Snapshot{
-	// 		SnapshotId:     snapshot.SnapshotID,
-	// 		SourceVolumeId: snapshot.VolumeID,
-	// 		CreationTime:   snapshot.CreationTime,
-	// 		SizeBytes:      snapshot.RestoreSize,
-	// 		ReadyToUse:     true,
-	// 	},
-	// }, nil
 }
 
-// DeleteSnapshot is part of implementing Snapshot & Restore functionality, and it will be supported in the future.
+// DeleteSnapshot is part of implementing Snapshot & Restore functionality.
+// This is not needed for TKM.
 func (d *Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest,
 ) (*csi.DeleteSnapshotResponse, error) {
-	d.log.Info("Request: DeleteSnapshot", "snapshot_id", req.GetSnapshotId())
-
-	snapshotID := req.GetSnapshotId()
-	if snapshotID == "" {
-		return nil, status.Error(codes.InvalidArgument, "must provide SnapshotId to DeleteSnapshot")
-	}
-
-	d.log.V(1).Info("Deleting snapshot in TKM API", "snapshot_id", snapshotID)
-
-	// TODO: Uncomment after client implementation is complete.
-	// _, err := d.TkmClient.DeleteVolumeSnapshot(snapshotID)
-	// if err != nil {
-	// 	if strings.Contains(err.Error(), "DatabaseVolumeSnapshotNotFoundError") {
-	// 		d.log.Info("Snapshot already deleted from TKM API", "volume_id", snapshotID)
-	// 		return &csi.DeleteSnapshotResponse{}, nil
-	// 	} else if strings.Contains(err.Error(), "DatabaseSnapshotCannotDeleteInUseError") {
-	// 		return nil,
-	// 			status.Errorf(
-	// 				codes.FailedPrecondition,
-	// 				"failed to delete snapshot %q, it is currently in use, err: %s",
-	// 				snapshotID,
-	// 				err
-	//			)
-	// 	}
-	// 	return nil, status.Errorf(codes.Internal, "failed to delete snapshot %q, err: %s", snapshotID, err)
-	// }
-	// return &csi.DeleteSnapshotResponse{}, nil
+	d.log.Info("Request: DeleteSnapshot, returning unimplemented", "snapshot_id", req.GetSnapshotId())
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ListSnapshots retrieves a list of existing snapshots as part of the Snapshot & Restore functionality.
+// This is not needed for TKM.
 func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
-	d.log.Info("Request: ListSnapshots")
-
-	snapshotID := req.GetSnapshotId()
-	sourceVolumeID := req.GetSourceVolumeId()
-
-	if req.GetStartingToken() != "" {
-		d.log.Error(
-			fmt.Errorf("ListSnapshots RPC received a Starting token, but pagination is not supported."+
-				"Ensure the request does not include a starting token"),
-			"Invalid Input")
-		return nil, status.Error(codes.Aborted, "starting-token not supported")
-	}
-
-	// case 1: SnapshotId is not empty, return snapshots that match the snapshot id
-	if len(snapshotID) != 0 {
-		d.log.V(1).Info("Fetching snapshot", "snapshot_id", snapshotID)
-
-		// Retrieve a specific snapshot by ID
-		// Todo: GetSnapshot to be implemented in tkmgo
-		// Todo: Un-comment post client implementation
-		// snapshot, err := d.TkmClient.GetSnapshot(snapshotID)
-		// if err != nil {
-		// 	// Todo: DatabaseSnapshotNotFoundError & DiskSnapshotNotFoundError are placeholders,
-		//  // it's still not clear what error will be returned by API (awaiting implementation - WIP)
-		// 	if strings.Contains(err.Error(), "DatabaseSnapshotNotFoundError") ||
-		// 		strings.Contains(err.Error(), "DiskSnapshotNotFoundError") {
-		// 		d.log.Info("ListSnapshots: no snapshot found, returning with success", "snapshot_id", snapshotID)
-		// 		return &csi.ListSnapshotsResponse{}, nil
-		// 	}
-		// 	d.log.Error(err, "Failed to list snapshot from TKM API" , "snapshot_id", snapshotID)
-		// 	return nil, status.Errorf(codes.Internal, "failed to list snapshot %q: %v", snapshotID, err)
-		// }
-		// return &csi.ListSnapshotsResponse{
-		// 	Entries: []*csi.ListSnapshotsResponse_Entry{convertSnapshot(snapshot)},
-		// }, nil
-	}
-
-	// case 2: Retrieve snapshots by source volume ID
-	if len(sourceVolumeID) != 0 {
-		d.log.V(1).Info("Fetching volume snapshots",
-			"operation", "list_snapshots",
-			"source_volume_id", sourceVolumeID)
-
-		// snapshots, err := d.TkmClient.ListSnapshots() // Todo: ListSnapshots to be implemented in tkmgo
-		// if err != nil {
-		// 	d.log.Error(err, "Failed to list snapshots for volume", "source_volume_id", sourceVolumeID)
-		// 	return nil, status.Errorf(codes.Internal, "failed to list snapshots for volume %q: %v", sourceVolumeID, err)
-		// }
-		//
-		// entries := []*csi.ListSnapshotsResponse_Entry{}
-		// for _, snapshot := range snapshots {
-		// 	if snapshot.VolID == sourceVolumeID {
-		// 		entries = append(entries, convertSnapshot(snapshot))
-		// 	}
-		// }
-		//
-		// return &csi.ListSnapshotsResponse{
-		// 	Entries: entries,
-		// }, nil
-	}
-
-	d.log.V(1).Info("Fetching all snapshots")
-
-	// case 3: Retrieve all snapshots if no filters are provided
-	// Todo: un-comment post client(tkmgo) implementation
-	// snapshots, err := d.TkmClient.ListSnapshots() // Todo: ListSnapshots to be implemented in tkmgo
-	// if err != nil {
-	// 	d.log.Error(err, "Failed to list snapshots from TKM API")
-	// 	return nil, status.Errorf(codes.Internal, "failed to list snapshots from TKM API: %v", err)
-	// }
-	//
-	// sort.Slice(snapshots, func(i, j int) bool {
-	// 	return snapshots[i].Id < snapshots[j].Id
-	// })
-	//
-	// entries := []*csi.ListSnapshotsResponse_Entry{}
-	// for _, snap := range snapshots {
-	// 	entries = append(entries, convertSnapshot(snap))
-	// }
-	//
-	// d.log.Info("Snapshots listed successfully", "total_snapshots", len(entries))
-	//
-	// return &csi.ListSnapshotsResponse{
-	// 	Entries: entries,
-	// }, nil
+	d.log.Info("Request: ListSnapshots, returning unimplemented")
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func getVolSizeInBytes(capRange *csi.CapacityRange) (int64, error) {
-	if capRange == nil {
-		return int64(DefaultVolumeSizeGB) * BytesInGigabyte, nil
-	}
-
-	// Volumes can be of a flexible size, but they must specify one of the fields, so we'll use that
-	bytes := capRange.GetRequiredBytes()
-	if bytes == 0 {
-		bytes = capRange.GetLimitBytes()
-	}
-
-	return bytes, nil
-}
-
-// Todo: Un-comment post client implementation is complete
-// Todo: Snapshot to be defined in tkmgo
-// convertSnapshot function converts a tkmgo.Snapshot object(API response) into a CSI ListSnapshotsResponse_Entry
-// func convertSnapshot(snap *tkmgo.Snapshot) *csi.ListSnapshotsResponse_Entry {
-// 	return &csi.ListSnapshotsResponse_Entry{
-// 		Snapshot: &csi.Snapshot{
-// 			SnapshotId:     snap.Id,
-// 			SourceVolumeId: snap.VolID,
-// 			CreationTime:   snap.CreationTime,
-// 			SizeBytes:      snap.SizeBytes,
-// 			ReadyToUse:     snap.ReadyToUse,
-// 		},
-// 	}
-// }
-
-// ControllerExpandVolume allows for offline expansion of Volumes
+// ControllerExpandVolume allows for offline expansion of Volumes.
+// This is not needed for TKM.
 func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest,
 ) (*csi.ControllerExpandVolumeResponse, error) {
-	volID := req.GetVolumeId()
-
-	d.log.Info("Request: ControllerExpandVolume", "volume_id", volID)
-
-	if volID == "" {
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to ControllerExpandVolume")
-	}
-
-	/*
-		// Get the volume from the TKM API
-		volume, err := d.TkmClient.GetVolume(volID)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "ControllerExpandVolume could not retrieve existing volume: %v", err)
-		}
-
-		if req.CapacityRange == nil {
-			return nil, status.Error(codes.InvalidArgument, "must provide a capacity range to ControllerExpandVolume")
-		}
-		bytes, err := getVolSizeInBytes(req.GetCapacityRange())
-		if err != nil {
-			return nil, err
-		}
-		desiredSize := bytes / BytesInGigabyte
-		if (bytes % BytesInGigabyte) != 0 {
-			desiredSize++
-		}
-		d.log.V(1).Info("Volume found",
-			"current_size", volume.SizeGigabytes,
-			"desired_size", desiredSize,
-			"state", volume.Status)
-
-		if volume.Status == "resizing" {
-			return nil, status.Error(codes.Aborted, "volume is already being resized")
-		}
-
-		if desiredSize <= int64(volume.SizeGigabytes) {
-			d.log.Info("Volume is currently larger that desired Size", "volume_id", volID)
-			return &csi.ControllerExpandVolumeResponse{
-				CapacityBytes: int64(volume.SizeGigabytes) * BytesInGigabyte,
-			  	NodeExpansionRequired: true}, nil
-		}
-
-		if volume.Status != "available" {
-			return nil, status.Error(codes.FailedPrecondition, "volume is not in an available state for OFFLINE expansion")
-		}
-
-		d.log.Info("Volume resize request sent", "size_gb", desiredSize, "volume_id", volID)
-		_, err = d.TkmClient.ResizeVolume(volID, int(desiredSize))
-		// Handles unexpected errors (e.g., API retry error or other upstream errors).
-		if err != nil {
-			d.log.Error(err, "Failed to resize volume in TKM API", "VolumeID", volID)
-			return nil, status.Errorf(codes.Internal, "cannot resize volume %s: %s", volID, err.Error())
-		}
-
-		// Resizes can take a while, double the number of normal retries
-		available, err := d.waitForVolumeStatus(volume, "available", TkmVolumeAvailableRetries*2)
-		if err != nil {
-			d.log.Error(err, "Unable to wait for volume availability in TKM API")
-			return nil, err
-		}
-
-		if !available {
-			return nil, status.Error(codes.Internal, "failed to wait for volume to be in an available state")
-		}
-
-		volume, _ = d.TkmClient.GetVolume(volID)
-	*/
-	d.log.Info("Volume successfully resized", "size_gb", 1 /*volume.SizeGigabytes*/, "volume_id", volID)
-	return &csi.ControllerExpandVolumeResponse{
-		CapacityBytes:         int64(1 /*volume.SizeGigabytes*/) * BytesInGigabyte,
-		NodeExpansionRequired: true,
-	}, nil
-}
-
-// ControllerGetVolume is for optional Kubernetes health checking of volumes and we don't support it yet
-func (d *Driver) ControllerGetVolume(context.Context, *csi.ControllerGetVolumeRequest,
-) (*csi.ControllerGetVolumeResponse, error) {
+	d.log.Info("Request: ControllerExpandVolume, returning unimplemented", "volume_id", req.GetVolumeId())
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ControllerModifyVolume modify volume
+// ControllerGetVolume is for optional Kubernetes health checking of volumes.
+// This is not needed for TKM.
+func (d *Driver) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest,
+) (*csi.ControllerGetVolumeResponse, error) {
+	d.log.Info("Request: ControllerGetVolume, returning unimplemented", "volume_id", req.GetVolumeId())
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+// ControllerModifyVolume is used to modify a given volume.
+// This is not needed for TKM.
 func (d *Driver) ControllerModifyVolume(_ context.Context, _ *csi.ControllerModifyVolumeRequest,
 ) (*csi.ControllerModifyVolumeResponse, error) {
+	d.log.Info("Request: ControllerModifyVolume, returning unimplemented")
 	return nil, status.Error(codes.Unimplemented, "")
 }
 

--- a/pkgs/driver/driver.go
+++ b/pkgs/driver/driver.go
@@ -29,22 +29,27 @@ var Version string = "0.0.1"
 // DefaultVolumeSizeGB is the default size in Gigabytes of an unspecified volume
 const DefaultVolumeSizeGB int = 10
 
+// CacheData contains metadata about a given Kernel Cache.
 type CacheData struct {
-	KernelName    string
-	Namespace     string
-	ClusterScoped bool
+	volumeSize    int64
+	clusterScoped bool
+	kernelName    string
+	namespace     string
 }
 
 // Driver implement the CSI endpoints for Identity, Node and Controller
 type Driver struct {
 	client.Client
-	SocketFilename  string
-	NodeName        string
-	Namespace       string
-	TestMode        bool
-	mounter         mount.Interface
-	grpcServer      *grpc.Server
-	log             logr.Logger
+	SocketFilename string
+	NodeName       string
+	Namespace      string
+	TestMode       bool
+	mounter        mount.Interface
+	grpcServer     *grpc.Server
+	log            logr.Logger
+
+	// volumeIdMapping stores metadata for each Kernel Cache and is
+	// indexed by the VolumeId sent from Kubelet.
 	volumeIdMapping map[string]CacheData
 
 	csi.UnimplementedNodeServer

--- a/pkgs/driver/identity_server.go
+++ b/pkgs/driver/identity_server.go
@@ -32,13 +32,6 @@ func (d *Driver) GetPluginCapabilities(context.Context, *csi.GetPluginCapabiliti
 					},
 				},
 			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
-					},
-				},
-			},
 		},
 	}, nil
 }

--- a/pkgs/driver/node_server.go
+++ b/pkgs/driver/node_server.go
@@ -18,109 +18,26 @@ const MaxVolumesPerNode int64 = 1024
 const TritonKernelCacheIndex string = "csi.tkm.io/tritonKernelCache"
 const TritonKernelCacheNamespaceIndex string = "csi.tkm.io/namespace"
 
-// NodeStageVolume is called after the volume is attached to the instance, so it can be partitioned,
-// formatted and mounted to a staging path
+// NodeStageVolume is called after the volume is attached to the instance, so it can be
+// partitioned, formatted and mounted to a staging path.
+// This is not needed for TKM.
 func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest,
 ) (*csi.NodeStageVolumeResponse, error) {
-	d.log.Info("Request: NodeStageVolume", "volume_id", req.VolumeId, "staging_target_path", req.StagingTargetPath)
-
-	if req.VolumeId == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumeId to NodeStageVolume"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to NodeStageVolume")
-	}
-	if req.StagingTargetPath == "" {
-		d.log.Error(fmt.Errorf("must provide a StagingTargetPath to NodeStageVolume"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "must provide a StagingTargetPath to NodeStageVolume")
-	}
-	if req.VolumeCapability == nil {
-		d.log.Error(fmt.Errorf("must provide a VolumeCapability to NodeStageVolume"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeCapability to NodeStageVolume")
-	}
-
-	d.log.V(1).Info("Formatting and mounting volume (staging)", "volume_id", req.VolumeId)
-
-	/*
-		// Find the disk attachment location
-		attachedDiskPath := d.DiskHotPlugger.PathForVolume(req.VolumeId)
-		if attachedDiskPath == "" {
-			d.log.Error(fmt.Errorf("path to volume (/dev/disk/by-id/VOLUME_ID) not found"),
-				"Invalid Input", "volume_id", req.VolumeId)
-			return nil, status.Errorf(codes.NotFound, "path to volume (/dev/disk/by-id/%s) not found", req.VolumeId)
-		}
-
-		// Format the volume if not already formatted
-		formatted, err := d.DiskHotPlugger.IsFormatted(attachedDiskPath)
-		if err != nil {
-			d.log.Error(err, "Formatted check errored", "path", attachedDiskPath)
-			return nil, err
-		}
-		d.log.V(1).Info("Is currently formatted?", "volume_id", req.VolumeId, "formatted", formatted)
-
-		if !formatted {
-			d.DiskHotPlugger.Format(d.DiskHotPlugger.PathForVolume(req.VolumeId), "ext4")
-		}
-
-		// Mount the volume if not already mounted
-		mounted, err := d.DiskHotPlugger.IsMounted(d.DiskHotPlugger.PathForVolume(req.VolumeId))
-		if err != nil {
-			d.log.Error(err, "Mounted check errored", "path", attachedDiskPath)
-			return nil, err
-		}
-		d.log.V(1).Info("Is currently mounted?", "volume_id", req.VolumeId, "mounted", formatted)
-
-		if !mounted {
-			mount := req.VolumeCapability.GetMount()
-			options := []string{}
-			if mount != nil {
-				options = mount.MountFlags
-			}
-			d.DiskHotPlugger.Mount(d.DiskHotPlugger.PathForVolume(req.VolumeId), req.StagingTargetPath, "ext4", options...)
-		}
-	*/
-
-	return &csi.NodeStageVolumeResponse{}, nil
+	d.log.Info("Request: NodeStageVolume, returning unimplemented",
+		"volume_id", req.VolumeId, "staging_target_path", req.StagingTargetPath)
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// NodeUnstageVolume unmounts the volume when it's finished with, ready for deletion
+// NodeUnstageVolume unmounts the volume when it's finished with, ready for deletion.
+// This is not needed for TKM.
 func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest,
 ) (*csi.NodeUnstageVolumeResponse, error) {
-	d.log.Info("Request: NodeUnstageVolume", "volume_id", req.VolumeId, "staging_target_path", req.StagingTargetPath)
-
-	if req.VolumeId == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumeId to NodeUnstageVolume"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to NodeUnstageVolume")
-	}
-	if req.StagingTargetPath == "" {
-		d.log.Error(fmt.Errorf("must provide a StagingTargetPath to NodeUnstageVolume"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "must provide a StagingTargetPath to NodeUnstageVolume")
-	}
-
-	/*
-		d.log.V(1).Info("Unmounting volume (unstaging)", "volume_id", req.VolumeId, "path", req.StagingTargetPath)
-		path := d.DiskHotPlugger.PathForVolume(req.VolumeId)
-
-		if path == "" && !d.TestMode {
-			d.log.Errorfmt.Errorf("path to volume (/dev/disk/by-id/VOLUME_ID) not found"), "volume_id", req.VolumeId)
-			return &csi.NodeUnstageVolumeResponse{}, nil
-		}
-
-		mounted, err := d.DiskHotPlugger.IsMounted(path)
-		if err != nil {
-			d.log.Error(err, "Mounted check errored", "path", path)
-			return nil, err
-		}
-		d.log.V(1).Info("Mounted check completed", "volume_id", req.VolumeId, "mounted", mounted)
-
-		if mounted {
-			d.log.V(1).Info("Unmounting", "volume_id", req.VolumeId, "mounted", mounted)
-			d.DiskHotPlugger.Unmount(path)
-		}
-	*/
-
-	return &csi.NodeUnstageVolumeResponse{}, nil
+	d.log.Info("Request: NodeUnstageVolume, returning unimplemented",
+		"volume_id", req.VolumeId, "staging_target_path", req.StagingTargetPath)
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// NodePublishVolume bind mounts the staging path into the container
+// NodePublishVolume bind mounts the staging path into the container.
 func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
 	d.log.Info("Request: NodePublishVolume",
@@ -130,87 +47,98 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		"VolumeCapability", req.VolumeCapability,
 		"VolumeContext", req.VolumeContext)
 
+	// Validate input parameters.
 	if req.VolumeId == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumeId to NodePublishVolume"), "Invalid Input")
+		d.log.Error(fmt.Errorf("must provide a VolumeId to NodePublishVolume"), "invalid input")
 		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to NodePublishVolume")
 	}
-	/*
-		if req.StagingTargetPath == "" {
-			d.log.Error(fmt.Errorf("must provide a StagingTargetPath to NodePublishVolume"), "Invalid Input")
-			return nil, status.Error(codes.InvalidArgument, "must provide a StagingTargetPath to NodePublishVolume")
-		}
-	*/
 	if req.TargetPath == "" {
-		d.log.Error(fmt.Errorf("must provide a TargetPath to NodePublishVolume"), "Invalid Input")
+		d.log.Error(fmt.Errorf("must provide a TargetPath to NodePublishVolume"), "invalid input")
 		return nil, status.Error(codes.InvalidArgument, "must provide a TargetPath to NodePublishVolume")
 	}
 	if req.VolumeCapability == nil {
-		d.log.Error(fmt.Errorf("must provide a VolumeCapability to NodePublishVolume"), "Invalid Input")
+		d.log.Error(fmt.Errorf("must provide a VolumeCapability to NodePublishVolume"), "invalid input")
 		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeCapability to NodePublishVolume")
 	}
 
+	// Determine if Namespace or Cluster Scoped.
 	clusterScoped := false
 	tkcNamespace, ok := req.VolumeContext[TritonKernelCacheNamespaceIndex]
 	if !ok {
 		// Namespace is not required. If not provided, then assume it is a Cluster scoped
-		// TritonKernelCache instance.
+		// TKMCache instance.
 		tkcNamespace = utils.ClusterScopedSubDir
 		clusterScoped = true
 	}
 
+	// The Pod Spec should contain CSI fields in the Volume Mount section, and that
+	// should contain the name of the TKMCache or TKMCacheCluster CRD that provides
+	// OCI Image. Pull that out of the input data. The namespace and CRD name is
+	// embedded in the directory structure on the Node if it has been downloaded and
+	// expanded.
 	tkcName, ok := req.VolumeContext[TritonKernelCacheIndex]
 	if !ok {
 		if clusterScoped {
-			d.log.Error(fmt.Errorf("must provide a TritonKernelCacheCluster"), "Invalid Input")
-			return nil, status.Error(codes.InvalidArgument, "must provide a TritonKernelCacheCluster NodePublishVolume")
+			d.log.Error(fmt.Errorf("must provide a TKMCacheCluster"), "invalid input")
+			return nil, status.Error(codes.InvalidArgument, "must provide a TKMCacheCluster NodePublishVolume")
 		} else {
-			d.log.Error(fmt.Errorf("must provide a TritonKernelCache"), "Invalid Input")
-			return nil, status.Error(codes.InvalidArgument, "must provide a TritonKernelCache NodePublishVolume")
+			d.log.Error(fmt.Errorf("must provide a TKMCache"), "invalid input")
+			return nil, status.Error(codes.InvalidArgument, "must provide a TKMCache NodePublishVolume")
 		}
 	}
 
+	// Build up the directory name from the namespace and CRD name.
 	sourcePath := utils.DefaultCacheDir
 	sourcePath = filepath.Join(sourcePath, tkcNamespace)
 	sourcePath = filepath.Join(sourcePath, tkcName)
 	if _, err := os.Stat(sourcePath); err != nil {
 		if os.IsNotExist(err) {
 			if clusterScoped {
-				d.log.Error(fmt.Errorf("TritonKernelCacheCluster has not been created"), "Invalid Input", "name", tkcName)
-				return nil, status.Error(codes.InvalidArgument, "TritonKernelCacheCluster has not been created NodePublishVolume")
+				d.log.Error(fmt.Errorf("TKMCacheCluster has not been created"), "invalid input", "name", tkcName)
+				return nil, status.Error(codes.InvalidArgument, "TKMCacheCluster has not been created NodePublishVolume")
 			} else {
-				d.log.Error(fmt.Errorf("TritonKernelCache has not been created"),
-					"Invalid Input", "name", tkcName, "namespace", tkcNamespace)
-				return nil, status.Error(codes.InvalidArgument, "TritonKernelCache has not been created NodePublishVolume")
+				d.log.Error(fmt.Errorf("TKMCache has not been created"),
+					"invalid input", "name", tkcName, "namespace", tkcNamespace)
+				return nil, status.Error(codes.InvalidArgument, "TKMCache has not been created NodePublishVolume")
 			}
 		} else {
-			d.log.Error(fmt.Errorf("unable to verify sourcePath"), "Invalid Input", "sourcePath", sourcePath)
+			d.log.Error(fmt.Errorf("unable to verify sourcePath"), "invalid input", "sourcePath", sourcePath)
 			return nil, status.Error(codes.InvalidArgument, "unable to verify sourcePath")
 		}
 	}
-	d.log.Info("Found TritonKernelCache CRD", "sourcePath", sourcePath)
+	d.log.Info("found TKMCache CRD", "sourcePath", sourcePath)
 
+	// Make sure the target directory is created. This is where the Kernel Cache will
+	// be mounted into the Pod.
 	if err := os.MkdirAll(req.TargetPath, 0o750); err != nil {
-		d.log.Error(err, "Failed to create target path", "volume_id", req.VolumeId, "targetPath", req.TargetPath)
+		d.log.Error(err, "failed to create target path", "volume_id", req.VolumeId, "targetPath", req.TargetPath)
 		return nil, err
 	}
 
-	// Check if already mounted
+	// Check if the Kernel Cache is already mounted.
 	mounted, err := utils.IsTargetBindMount(req.TargetPath)
 	if err != nil {
 		d.log.Error(fmt.Errorf("unable to verify if targetPath already mounted"),
-			"Invalid Input", "targetPath", req.TargetPath)
+			"invalid input", "targetPath", req.TargetPath)
 		return nil, status.Error(codes.InvalidArgument, "unable to verify if targetPath already mounted")
 	}
 
-	// If Already Mounted
+	// Code needs to be idempotent, so if already mounted, just return.
 	if mounted {
 		_, ok := d.volumeIdMapping[req.VolumeId]
 		if !ok {
+			size, err := utils.DirSize(sourcePath)
+			if err != nil {
+				size = 0
+				d.log.Error(err, "unable to get directory size", "sourcePath", sourcePath)
+			}
+
 			// Save off the VolumeId mapping to CRD Info
 			d.volumeIdMapping[req.VolumeId] = CacheData{
-				KernelName:    tkcName,
-				Namespace:     tkcNamespace,
-				ClusterScoped: clusterScoped,
+				volumeSize:    size,
+				clusterScoped: clusterScoped,
+				kernelName:    tkcName,
+				namespace:     tkcNamespace,
 			}
 		}
 
@@ -227,15 +155,22 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	}
 
 	if err := d.mounter.Mount(sourcePath, req.TargetPath, "", options); err != nil {
-		d.log.Error(fmt.Errorf("bind mount failed"), "Invalid Input", "sourcePath", sourcePath, "targetPath", req.TargetPath)
+		d.log.Error(fmt.Errorf("bind mount failed"), "invalid input", "sourcePath", sourcePath, "targetPath", req.TargetPath)
 		return nil, status.Error(codes.Internal, "bind mount failed")
 	}
 
 	// Save off the VolumeId mapping to CRD Info
+	size, err := utils.DirSize(sourcePath)
+	if err != nil {
+		size = 0
+		d.log.Error(err, "unable to get directory size", "sourcePath", sourcePath)
+	}
+
 	d.volumeIdMapping[req.VolumeId] = CacheData{
-		KernelName:    tkcName,
-		Namespace:     tkcNamespace,
-		ClusterScoped: clusterScoped,
+		volumeSize:    size,
+		clusterScoped: clusterScoped,
+		kernelName:    tkcName,
+		namespace:     tkcNamespace,
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -249,19 +184,19 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 		"TargetPath", req.TargetPath)
 
 	if req.VolumeId == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumeId to NodeUnpublishVolume"), "Invalid Input")
+		d.log.Error(fmt.Errorf("must provide a VolumeId to NodeUnpublishVolume"), "invalid input")
 		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to NodeUnpublishVolume")
 	}
 	if req.TargetPath == "" {
-		d.log.Error(fmt.Errorf("must provide a TargetPath to NodeUnpublishVolume"), "Invalid Input")
+		d.log.Error(fmt.Errorf("must provide a TargetPath to NodeUnpublishVolume"), "invalid input")
 		return nil, status.Error(codes.InvalidArgument, "must provide a TargetPath to NodeUnpublishVolume")
 	}
 
-	/*cacheData*/
+	/* Check if Cache Data was created */
 	_, ok := d.volumeIdMapping[req.VolumeId]
 	if !ok {
-		d.log.Error(fmt.Errorf("could not map VolumeId to TritonKernelCache"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "could not map VolumeId to TritonKernelCache NodeUnpublishVolume")
+		d.log.Error(fmt.Errorf("could not map VolumeId to TKMCache"), "invalid input")
+		return nil, status.Error(codes.InvalidArgument, "could not map VolumeId to TKMCache NodeUnpublishVolume")
 	}
 
 	// Check if already mounted
@@ -282,7 +217,7 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	// Only attempt to unmount if it's mounted
 	if mounted {
 		if err := d.mounter.Unmount(req.TargetPath); err != nil {
-			d.log.Error(fmt.Errorf("umount failed"), "Invalid Input", "targetPath", req.TargetPath)
+			d.log.Error(fmt.Errorf("umount failed"), "invalid input", "targetPath", req.TargetPath)
 			return nil, status.Error(codes.Internal, "umount failed")
 		}
 	} else {
@@ -310,137 +245,64 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 	}, nil
 }
 
-type VolumeStatistics struct {
-	AvailableBytes, TotalBytes, UsedBytes    int64
-	AvailableInodes, TotalInodes, UsedInodes int64
-}
-
 // NodeGetVolumeStats returns the volume capacity statistics available for the the given volume
 func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest,
 ) (*csi.NodeGetVolumeStatsResponse, error) {
 	d.log.Info("Request: NodeGetVolumeStats", "volume_id", req.VolumeId)
 
 	if req.VolumeId == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumeId to NodeGetVolumeStats"), "Invalid Input")
+		d.log.Error(fmt.Errorf("must provide a VolumeId to NodeGetVolumeStats"), "invalid input")
 		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to NodeGetVolumeStats")
 	}
 
 	volumePath := req.VolumePath
 	if volumePath == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumePath to NodeGetVolumeStats"), "Invalid Input")
+		d.log.Error(fmt.Errorf("must provide a VolumePath to NodeGetVolumeStats"), "invalid input")
 		return nil, status.Error(codes.InvalidArgument, "must provide a VolumePath to NodeGetVolumeStats")
 	}
 
-	/*
-		mounted, err := d.DiskHotPlugger.IsMounted(volumePath)
-		if err != nil {
-			log.Error(err, "Failed to check if volume path is mounted", "volume_id", req.VolumeId, "path", volumePath)
-			return nil, status.Errorf(codes.Internal, "failed to check if volume path %q is mounted: %s", volumePath, err)
-		}
-
-		if !mounted {
-			log.Error(fmt.Errorf("Volume path is not mounted"), "Invalid Input", "volume_id", req.VolumeId, "path", volumePath)
-			return nil, status.Errorf(codes.NotFound, "volume path %q is not mounted", volumePath)
-		}
-
-		stats, err := d.DiskHotPlugger.GetStatistics(volumePath)
-		if err != nil {
-			log.Error(err, "Failed to retrieve capacity statistics", "volume_id", req.VolumeId, "path", volumePath)
-			return nil,
-				status.Errorf(
-					codes.Internal,
-					"failed to retrieve capacity statistics for volume path %q: %s",
-					volumePath,
-					err,
-				)
-		}
-	*/
-
-	var stats VolumeStatistics
+	/* Check if Cache Data was created */
+	cacheData, ok := d.volumeIdMapping[req.VolumeId]
+	if !ok {
+		d.log.Error(fmt.Errorf("could not map VolumeId to TKMCache"), "invalid input")
+		return nil, status.Error(codes.InvalidArgument, "could not map VolumeId to TKMCache NodeUnpublishVolume")
+	}
 
 	d.log.Info("Node capacity statistics retrieved",
-		"bytes_available", stats.AvailableBytes,
-		"bytes_total", stats.TotalBytes,
-		"bytes_used", stats.UsedBytes,
-		"inodes_available", stats.AvailableInodes,
-		"inodes_total", stats.TotalInodes,
-		"inodes_used", stats.UsedInodes)
+		"bytes_available", 0,
+		"bytes_total", cacheData.volumeSize,
+		"bytes_used", cacheData.volumeSize)
 
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
 			{
-				Available: stats.AvailableBytes,
-				Total:     stats.TotalBytes,
-				Used:      stats.UsedBytes,
+				Available: 0,
+				Total:     cacheData.volumeSize,
+				Used:      cacheData.volumeSize,
 				Unit:      csi.VolumeUsage_BYTES,
-			},
-			{
-				Available: stats.AvailableInodes,
-				Total:     stats.TotalInodes,
-				Used:      stats.UsedInodes,
-				Unit:      csi.VolumeUsage_INODES,
 			},
 		},
 	}, nil
 }
 
-// NodeExpandVolume is used to expand the filesystem inside volumes
+// NodeExpandVolume is used to expand the filesystem inside volumes.
+// This is not needed for TKM.
 func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest,
 ) (*csi.NodeExpandVolumeResponse, error) {
-	d.log.Info("Request: NodeExpandVolume", "volume_id", req.VolumeId, "target_path", req.VolumePath)
-	if req.VolumeId == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumeId to NodeExpandVolume"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumeId to NodeExpandVolume")
-	}
-	if req.VolumePath == "" {
-		d.log.Error(fmt.Errorf("must provide a VolumePath to NodeExpandVolume"), "Invalid Input")
-		return nil, status.Error(codes.InvalidArgument, "must provide a VolumePath to NodeExpandVolume")
-	}
-
-	/*
-		_, err := d.TkmClient.GetVolume(req.VolumeId)
-		if err != nil {
-			d.log.Error(err, "Failed to find VolumeID to NodeExpandVolume", "volume_id", req.VolumeId)
-			return nil, status.Errorf(codes.NotFound, "unable to find VolumeID %q to NodeExpandVolume: %s", req.VolumeId, err)
-		}
-		// Find the disk attachment location
-		attachedDiskPath := d.DiskHotPlugger.PathForVolume(req.VolumeId)
-		if attachedDiskPath == "" {
-			log.Error(fmt.Errorf("path to volume (/dev/disk/by-id/VOLUME_ID) not found"),
-				"Invalid Input", "volume_id", req.VolumeId)
-			return nil, status.Errorf(codes.NotFound, "path to volume (/dev/disk/by-id/%s) not found", req.VolumeId)
-		}
-
-		log.Info("Expanding Volume", "volume_id", req.VolumeId, "path", attachedDiskPath)
-		err = d.DiskHotPlugger.ExpandFilesystem(d.DiskHotPlugger.PathForVolume(req.VolumeId))
-		if err != nil {
-			log.Error(err, "Failed to expand filesystem", "volume_id", req.VolumeId)
-			return nil, status.Errorf(codes.Internal, "failed to expand file system: %s", err)
-		}
-	*/
-
-	// TODO: Get new size for resposne
-
-	return &csi.NodeExpandVolumeResponse{}, nil
+	d.log.Info("Request: NodeExpandVolume, returning unimplemented",
+		"volume_id", req.VolumeId, "target_path", req.VolumePath)
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // NodeGetCapabilities returns the capabilities that this node and driver support
 func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest,
 ) (*csi.NodeGetCapabilitiesResponse, error) {
-	// Intentionally don't return VOLUME_CONDITION and NODE_GET_VOLUME_STATS
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{
 			{
 				Type: &csi.NodeServiceCapability_Rpc{
 					Rpc: &csi.NodeServiceCapability_RPC{
 						Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
-					},
-				},
-			},
-			{
-				Type: &csi.NodeServiceCapability_Rpc{
-					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
 					},
 				},
 			},


### PR DESCRIPTION
There are about 20 functions in the CSI API and TKM only needs to support about 4 of them (based on testing). Most of the unused functions had commented out sample code. Removed all the sample code and implemented what was needed.